### PR TITLE
Fixes out-of-spec SSE streaming implementation

### DIFF
--- a/app.js
+++ b/app.js
@@ -222,7 +222,7 @@ function streamNextClaudeResponseChunk(message, res) {
                     }]
                 };
             
-                res.write('\ndata: ' + JSON.stringify(streamData));
+                res.write('\n\ndata: ' + JSON.stringify(streamData));
     
                 if (!stillTyping) {
                     finishStream(res);
@@ -271,7 +271,7 @@ function getClaudeResponse(message, res) {
  */
 function finishStream(res) {
     lastMessage = '';
-    res.write('\ndata: [DONE]');
+    res.write('\n\ndata: [DONE]');
     res.end();
 }
 

--- a/app.js
+++ b/app.js
@@ -75,6 +75,7 @@ app.post('/(.*)/chat/completions', async (req, res, next) => {
         let timeout = null;
 
         if (stream) {
+            res.setHeader("Content-Type", "text/event-stream");
             console.log("Opened stream for Claude's response.");
             streamQueue = Promise.resolve();
             ws.on("message", (message) => {


### PR DESCRIPTION
This PR addresses an issue wherein Slaude was delineating SSE messages with a single newline, instead of two newlines [as the spec requires](https://developer.mozilla.org/en-US/docs/Web/API/Server-sent_events/Using_server-sent_events#sending_events_from_the_server).

While this worked fine in SillyTavern before, I recently opened https://github.com/Cohee1207/SillyTavern/pull/340 to fix an unrelated streaming issue, and in so doing broke Slaude's streaming (because SillyTavern is now more strict and expects two newlines).

Port of https://github.com/bfs15/slaude/pull/2